### PR TITLE
Write correct minmax values to header

### DIFF
--- a/laz-perf/io.hpp
+++ b/laz-perf/io.hpp
@@ -32,6 +32,7 @@
 #define __io_hpp__
 
 #include <fstream>
+#include <limits>
 #include <string.h>
 #include <mutex>
 
@@ -757,6 +758,8 @@ namespace laszip {
 
 				header to_header() const {
 					header h; memset(&h, 0, sizeof(h)); // clear out header
+					h.min = {std::numeric_limits<double>::max(), std::numeric_limits<double>::max(), std::numeric_limits<double>::max()};
+					h.max = {std::numeric_limits<double>::lowest(), std::numeric_limits<double>::lowest(), std::numeric_limits<double>::lowest()};
 
 					h.offset.x = offset.x;
 					h.offset.y = offset.y;

--- a/test/io_tests.cpp
+++ b/test/io_tests.cpp
@@ -513,3 +513,34 @@ TEST(io_tests, can_decode_large_files_from_memory) {
 	}
 }
 
+TEST(io_tests, writes_bbox_to_header) {
+	using namespace laszip;
+	using namespace laszip::formats;
+
+	factory::record_schema schema;
+	schema(factory::record_item::POINT10);
+
+	// First write a few points
+	std::string filename = "/tmp/header__bbox.laz";
+	io::writer::file f(filename, schema,
+			io::writer::config(vector3<double>(0.01, 0.01, 0.01),
+							   vector3<double>(0.0, 0.0, 0.0)));
+	las::point10 p1, p2;
+	p1.x = 100; p2.x = 200;
+	p1.y = -200; p2.y = -300;
+	p1.z = 300; p2.z = -400;
+
+	f.writePoint((char*)&p1);
+	f.writePoint((char*)&p2);
+	f.close();
+
+	// Now check that the file has correct bounding box
+  std::ifstream ifs(filename);
+  io::reader::file reader(ifs);
+  EXPECT_EQ(reader.get_header().min.x, 1.0);
+  EXPECT_EQ(reader.get_header().max.x, 2.0);
+  EXPECT_EQ(reader.get_header().min.y, -3.0);
+  EXPECT_EQ(reader.get_header().max.y, -2.0);
+  EXPECT_EQ(reader.get_header().min.z, -4.0);
+  EXPECT_EQ(reader.get_header().max.z, 3.0);
+}


### PR DESCRIPTION
Currently the header is zeroed out when writing new files. This means that in the general case header Min X/Y/Z will always be equal to zero, no matter what is actually in the file.
